### PR TITLE
fix: remove hard-coded http://localhost:5500 in "{FROM}" statements

### DIFF
--- a/pyscript.toml
+++ b/pyscript.toml
@@ -2,7 +2,7 @@ name = "Firsr PyScript App"
 description = "An example of how to build pyscript app."
 packages = ["Pillow", "distinctipy"]
 [files]
-"{FROM}" = "http://localhost:5500"
+"{FROM}" = ""
 "{TO}" = "."
 
 "{FROM}/src/manager.py" = "{TO}/"
@@ -12,5 +12,3 @@ packages = ["Pillow", "distinctipy"]
 "{FROM}/assets/Anonymous_Pro.ttf" = "{TO}/assets/Anonymous_Pro.ttf"
 
 # END COMMON PART
-
-

--- a/toml/00000.toml
+++ b/toml/00000.toml
@@ -2,7 +2,7 @@ name = "Firsr PyScript App"
 description = "An example of how to build pyscript app."
 packages = ["Pillow", "distinctipy"]
 [files]
-"{FROM}" = "http://localhost:5500"
+"{FROM}" = ""
 "{TO}" = "."
 
 "{FROM}/src/manager.py" = "{TO}/"
@@ -13,4 +13,3 @@ packages = ["Pillow", "distinctipy"]
 
 # END COMMON PART
 "{FROM}/data/docs/00000/TM065797_The_Curse_of_Artemisia_Fragment_WDL4310.pap" = "{TO}/data/docs/00000/TM065797_The_Curse_of_Artemisia_Fragment_WDL4310.pap"
-

--- a/toml/00001.toml
+++ b/toml/00001.toml
@@ -2,7 +2,7 @@ name = "Firsr PyScript App"
 description = "An example of how to build pyscript app."
 packages = ["Pillow", "distinctipy"]
 [files]
-"{FROM}" = "http://localhost:5500"
+"{FROM}" = ""
 "{TO}" = "."
 
 "{FROM}/src/manager.py" = "{TO}/"
@@ -13,4 +13,3 @@ packages = ["Pillow", "distinctipy"]
 
 # END COMMON PART
 "{FROM}/data/docs/00001/TM062931_TimotheusPersae_crop1.pap" = "{TO}/data/docs/00001/TM062931_TimotheusPersae_crop1.pap"
-

--- a/toml/00002.toml
+++ b/toml/00002.toml
@@ -2,7 +2,7 @@ name = "Firsr PyScript App"
 description = "An example of how to build pyscript app."
 packages = ["Pillow", "distinctipy"]
 [files]
-"{FROM}" = "http://localhost:5500"
+"{FROM}" = ""
 "{TO}" = "."
 
 "{FROM}/src/manager.py" = "{TO}/"
@@ -13,4 +13,3 @@ packages = ["Pillow", "distinctipy"]
 
 # END COMMON PART
 "{FROM}/data/docs/00002/TM062931_TimotheusPersae_crop2.pap" = "{TO}/data/docs/00002/TM062931_TimotheusPersae_crop2.pap"
-

--- a/toml/00003.toml
+++ b/toml/00003.toml
@@ -2,7 +2,7 @@ name = "Firsr PyScript App"
 description = "An example of how to build pyscript app."
 packages = ["Pillow", "distinctipy"]
 [files]
-"{FROM}" = "http://localhost:5500"
+"{FROM}" = ""
 "{TO}" = "."
 
 "{FROM}/src/manager.py" = "{TO}/"
@@ -13,4 +13,3 @@ packages = ["Pillow", "distinctipy"]
 
 # END COMMON PART
 "{FROM}/data/docs/00003/TM062931_TimotheusPersae_crop3.pap" = "{TO}/data/docs/00003/TM062931_TimotheusPersae_crop3.pap"
-

--- a/toml/00005.toml
+++ b/toml/00005.toml
@@ -2,7 +2,7 @@ name = "Firsr PyScript App"
 description = "An example of how to build pyscript app."
 packages = ["Pillow", "distinctipy"]
 [files]
-"{FROM}" = "http://localhost:5500"
+"{FROM}" = ""
 "{TO}" = "."
 
 "{FROM}/src/manager.py" = "{TO}/"
@@ -13,4 +13,3 @@ packages = ["Pillow", "distinctipy"]
 
 # END COMMON PART
 "{FROM}/data/docs/00005/TM065795_Derveni_CavalloMaehler_DerveniPage27.pap" = "{TO}/data/docs/00005/TM065795_Derveni_CavalloMaehler_DerveniPage27.pap"
-

--- a/toml/00006.toml
+++ b/toml/00006.toml
@@ -2,7 +2,7 @@ name = "Firsr PyScript App"
 description = "An example of how to build pyscript app."
 packages = ["Pillow", "distinctipy"]
 [files]
-"{FROM}" = "http://localhost:5500"
+"{FROM}" = ""
 "{TO}" = "."
 
 "{FROM}/src/manager.py" = "{TO}/"
@@ -13,4 +13,3 @@ packages = ["Pillow", "distinctipy"]
 
 # END COMMON PART
 "{FROM}/data/docs/00006/TM065795_Derveni_UNESCO_greece_derveni_papyrus_amth2.pap" = "{TO}/data/docs/00006/TM065795_Derveni_UNESCO_greece_derveni_papyrus_amth2.pap"
-

--- a/toml/00009.toml
+++ b/toml/00009.toml
@@ -2,7 +2,7 @@ name = "Firsr PyScript App"
 description = "An example of how to build pyscript app."
 packages = ["Pillow", "distinctipy"]
 [files]
-"{FROM}" = "http://localhost:5500"
+"{FROM}" = ""
 "{TO}" = "."
 
 "{FROM}/src/manager.py" = "{TO}/"
@@ -13,4 +13,3 @@ packages = ["Pillow", "distinctipy"]
 
 # END COMMON PART
 "{FROM}/data/docs/00009/TM065795_Derveni_UNESCO_papyrus_amth_5.pap" = "{TO}/data/docs/00009/TM065795_Derveni_UNESCO_papyrus_amth_5.pap"
-

--- a/toml/10000.toml
+++ b/toml/10000.toml
@@ -2,7 +2,7 @@ name = "Firsr PyScript App"
 description = "An example of how to build pyscript app."
 packages = ["Pillow", "distinctipy"]
 [files]
-"{FROM}" = "http://localhost:5500"
+"{FROM}" = ""
 "{TO}" = "."
 
 "{FROM}/src/manager.py" = "{TO}/"
@@ -13,4 +13,3 @@ packages = ["Pillow", "distinctipy"]
 
 # END COMMON PART
 "{FROM}/data/docs/10000/2999px-Lyon-TableClaudienne_bronzo.pap" = "{TO}/data/docs/10000/2999px-Lyon-TableClaudienne_bronzo.pap"
-

--- a/toml/10001.toml
+++ b/toml/10001.toml
@@ -2,7 +2,7 @@ name = "Firsr PyScript App"
 description = "An example of how to build pyscript app."
 packages = ["Pillow", "distinctipy"]
 [files]
-"{FROM}" = "http://localhost:5500"
+"{FROM}" = ""
 "{TO}" = "."
 
 "{FROM}/src/manager.py" = "{TO}/"
@@ -13,4 +13,3 @@ packages = ["Pillow", "distinctipy"]
 
 # END COMMON PART
 "{FROM}/data/docs/10001/1327936773345_epigrafe.pap" = "{TO}/data/docs/10001/1327936773345_epigrafe.pap"
-

--- a/toml/10002.toml
+++ b/toml/10002.toml
@@ -2,7 +2,7 @@ name = "Firsr PyScript App"
 description = "An example of how to build pyscript app."
 packages = ["Pillow", "distinctipy"]
 [files]
-"{FROM}" = "http://localhost:5500"
+"{FROM}" = ""
 "{TO}" = "."
 
 "{FROM}/src/manager.py" = "{TO}/"
@@ -13,4 +13,3 @@ packages = ["Pillow", "distinctipy"]
 
 # END COMMON PART
 "{FROM}/data/docs/10002/epi_apollonia.pap" = "{TO}/data/docs/10002/epi_apollonia.pap"
-

--- a/toml/10003.toml
+++ b/toml/10003.toml
@@ -2,7 +2,7 @@ name = "Firsr PyScript App"
 description = "An example of how to build pyscript app."
 packages = ["Pillow", "distinctipy"]
 [files]
-"{FROM}" = "http://localhost:5500"
+"{FROM}" = ""
 "{TO}" = "."
 
 "{FROM}/src/manager.py" = "{TO}/"
@@ -13,4 +13,3 @@ packages = ["Pillow", "distinctipy"]
 
 # END COMMON PART
 "{FROM}/data/docs/10003/P.Oxy_bizantino.pap" = "{TO}/data/docs/10003/P.Oxy_bizantino.pap"
-

--- a/toml/10004.toml
+++ b/toml/10004.toml
@@ -2,7 +2,7 @@ name = "Firsr PyScript App"
 description = "An example of how to build pyscript app."
 packages = ["Pillow", "distinctipy"]
 [files]
-"{FROM}" = "http://localhost:5500"
+"{FROM}" = ""
 "{TO}" = "."
 
 "{FROM}/src/manager.py" = "{TO}/"
@@ -13,4 +13,3 @@ packages = ["Pillow", "distinctipy"]
 
 # END COMMON PART
 "{FROM}/data/docs/10004/TM3563_P.Tor.Choach.12.01.pap" = "{TO}/data/docs/10004/TM3563_P.Tor.Choach.12.01.pap"
-

--- a/toml/10005.toml
+++ b/toml/10005.toml
@@ -2,7 +2,7 @@ name = "Firsr PyScript App"
 description = "An example of how to build pyscript app."
 packages = ["Pillow", "distinctipy"]
 [files]
-"{FROM}" = "http://localhost:5500"
+"{FROM}" = ""
 "{TO}" = "."
 
 "{FROM}/src/manager.py" = "{TO}/"
@@ -13,4 +13,3 @@ packages = ["Pillow", "distinctipy"]
 
 # END COMMON PART
 "{FROM}/data/docs/10005/latino_graff.pap" = "{TO}/data/docs/10005/latino_graff.pap"
-

--- a/toml/10006.toml
+++ b/toml/10006.toml
@@ -2,7 +2,7 @@ name = "Firsr PyScript App"
 description = "An example of how to build pyscript app."
 packages = ["Pillow", "distinctipy"]
 [files]
-"{FROM}" = "http://localhost:5500"
+"{FROM}" = ""
 "{TO}" = "."
 
 "{FROM}/src/manager.py" = "{TO}/"
@@ -13,4 +13,3 @@ packages = ["Pillow", "distinctipy"]
 
 # END COMMON PART
 "{FROM}/data/docs/10006/latino_murale.pap" = "{TO}/data/docs/10006/latino_murale.pap"
-

--- a/toml/10007.toml
+++ b/toml/10007.toml
@@ -2,7 +2,7 @@ name = "Firsr PyScript App"
 description = "An example of how to build pyscript app."
 packages = ["Pillow", "distinctipy"]
 [files]
-"{FROM}" = "http://localhost:5500"
+"{FROM}" = ""
 "{TO}" = "."
 
 "{FROM}/src/manager.py" = "{TO}/"
@@ -13,4 +13,3 @@ packages = ["Pillow", "distinctipy"]
 
 # END COMMON PART
 "{FROM}/data/docs/10007/Pantheon.pap" = "{TO}/data/docs/10007/Pantheon.pap"
-

--- a/toml/10008.toml
+++ b/toml/10008.toml
@@ -2,7 +2,7 @@ name = "Firsr PyScript App"
 description = "An example of how to build pyscript app."
 packages = ["Pillow", "distinctipy"]
 [files]
-"{FROM}" = "http://localhost:5500"
+"{FROM}" = ""
 "{TO}" = "."
 
 "{FROM}/src/manager.py" = "{TO}/"
@@ -13,4 +13,3 @@ packages = ["Pillow", "distinctipy"]
 
 # END COMMON PART
 "{FROM}/data/docs/10008/sesterzio_nerone.pap" = "{TO}/data/docs/10008/sesterzio_nerone.pap"
-

--- a/toml/10009.toml
+++ b/toml/10009.toml
@@ -2,7 +2,7 @@ name = "Firsr PyScript App"
 description = "An example of how to build pyscript app."
 packages = ["Pillow", "distinctipy"]
 [files]
-"{FROM}" = "http://localhost:5500"
+"{FROM}" = ""
 "{TO}" = "."
 
 "{FROM}/src/manager.py" = "{TO}/"
@@ -13,4 +13,3 @@ packages = ["Pillow", "distinctipy"]
 
 # END COMMON PART
 "{FROM}/data/docs/10009/eng.pap" = "{TO}/data/docs/10009/eng.pap"
-


### PR DESCRIPTION
With "{FROM}" = "" the browser can still resolve the paths against whatever origin served `index.html`, meaning commands like `python3 -m http.server 5500` still work as they should and deploy the website on `http://localhost:5500`.

The biggest advantage of removing hard-coded `http://localhost:5500`, however, is that in real-world deployment we can replace the domain by any `example.com` simply via network configuration, i.e., without having to touch on the source code here